### PR TITLE
Fix gh actions to use foundry

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,19 +25,25 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          cache : yarn
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Run hardhat node, deploy contracts (& generate contracts typescript output)
-        run: yarn chain & yarn deploy 
+      - name: Install foundry-toolchain
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run foundry node, deploy contracts (& generate contracts typescript output)
+        env:
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+        run: yarn chain & yarn deploy
+        id: build
 
       - name: Run nextjs lint
         run: yarn next:lint --max-warnings=0
+        id: lint-frontend
 
       - name: Check typings on nextjs
         run: yarn next:check-types
-
-      - name: Run hardhat lint
-        run: yarn hardhat:lint --max-warnings=0


### PR DESCRIPTION
### Description : 

These new changes will : 
1. Run foundry chain 
2. Runs `yarn deploy`
3. Does the linting and types check for only frontend. 

### TODO: 

- [ ] Add `ETHERSCAN_API_KEY` in [Github secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) I think we can use API key which comes with SE-2

I think I don't have the permission to add GH secrets, @steve0xp or @MattPereira could you please add it 🙌

Fixes #23 